### PR TITLE
docs: sleep 30コマンドを使用したワークフロー確認手順をルールに追加

### DIFF
--- a/cursorrules
+++ b/cursorrules
@@ -81,14 +81,13 @@
 - CIの実行結果はPRにコメントとして自動的に追加される
 - ワークフローファイルは`.github/workflows`に配置
 - Node.jsのバージョンは`.tool-versions`で管理
-- ワークフローの確認手順
-  - プッシュ後は30秒ごとにワークフローの状態を確認
-  - `gh run list --workflow="PR Check CI" --limit 1`で確認
-  - 失敗時は`gh run view <run-id> --log-failed`でログを確認
-  - 修正後は再度30秒ごとに確認
-  - 全てのチェックが通過するまで繰り返す
-  - 成功したらPRをマージ
-  - マージ後はmainブランチに切り替えて最新の状態に更新
+- ワークフロー確認手順
+  1. プッシュ後、`gh run list --workflow="PR Check CI" --limit 1` で状態を確認
+  2. `sleep 30` コマンドで30秒待機
+  3. 再度 `gh run list` で確認
+  4. 失敗時は `gh run view` でログを確認して対応
+  5. すべてのチェックがパスするまで2-3を繰り返す
+  6. 成功したらPRをマージしてmainブランチを更新
 
 ## Next.jsアプリケーションルール
 - App Router規約に従ったファイル配置


### PR DESCRIPTION
## 概要
ワークフローの確認手順をルールとして追加します。

## 変更内容
- CI/CDセクションにワークフローの確認手順を追加
  - プッシュ後の確認タイミング（sleep 30コマンドを使用）
  - 使用するコマンド（gh run list, gh run view）
  - 失敗時の対応手順
  - 成功時の手順

## 確認したこと
- [x] 単体テストを実行した
- [x] 動作確認を実行した
- [x] リンター/型チェックを実行した

### 動作確認の内容
- cursorrules ファイルの内容が正しく更新されていることを確認
- 追加したルールの内容が明確で理解しやすいことを確認
- sleep 30コマンドを使用した待機時間の指定が明確であることを確認

## 補足
なし
